### PR TITLE
Fix support for Julia down to 1.4

### DIFF
--- a/.github/workflows/OS-UnitTests.yml
+++ b/.github/workflows/OS-UnitTests.yml
@@ -12,7 +12,16 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        version:
+          - '1.4'
+          - '1.5'
+          - '1.6'
+        os:
+          - ubuntu-latest
+          - macOS-latest
+          - windows-latest
+        arch:
+          - x64
 
     runs-on: ${{ matrix.os }}
 

--- a/bors.toml
+++ b/bors.toml
@@ -1,7 +1,13 @@
 status = [
-  "test-os (ubuntu-latest)",
-  "test-os (windows-latest)",
-  "test-os (macos-latest)",
+  "test-os 1.4 - (ubuntu-latest)",
+  "test-os 1.4 - (windows-latest)",
+  "test-os 1.4 - (macos-latest)",
+  "test-os 1.5 - (ubuntu-latest)",
+  "test-os 1.5 - (windows-latest)",
+  "test-os 1.5 - (macos-latest)",
+  "test-os 1.6 - (ubuntu-latest)",
+  "test-os 1.6 - (windows-latest)",
+  "test-os 1.6 - (macos-latest)",
   "buildkite/climatemachinecore-ci",
   "format",
   "docbuild"

--- a/src/Geometry/vectors.jl
+++ b/src/Geometry/vectors.jl
@@ -16,7 +16,9 @@ Base.length(ax::AbstractAxis) = length(ax.range)
 Base.iterate(ax::AbstractAxis) = iterate(ax.range)
 Base.iterate(ax::AbstractAxis, i) = iterate(ax.range, i)
 Base.getindex(ax::AbstractAxis, i) = getindex(ax.range, i)
-Base.unitrange(ax::AbstractAxis) = Base.unitrange(ax.range)
+if VERSION >= v"1.6"
+    Base.unitrange(ax::AbstractAxis) = Base.UnitRange(ax.range)
+end
 Base.checkindex(::Type{Bool}, ax::AbstractAxis, i) =
     Base.checkindex(Bool, ax.range, i)
 Base.lastindex(ax::AbstractAxis) = Base.lastindex(ax.range)


### PR DESCRIPTION
Not that we'll be running on lower versions of Julia, but it seems that this is all we need to support Julia versions down to 1.4.