### PR TITLE
Define Base.axes(::Field) to return the space, instead of a tuple

### DIFF
--- a/src/Fields/broadcast.jl
+++ b/src/Fields/broadcast.jl
@@ -70,10 +70,6 @@ Base.axes(bc::Base.Broadcast.Broadcasted{<:AbstractFieldStyle}) =
 _axes(bc, ::Nothing) = Base.Broadcast.combine_axes(bc.args...)
 _axes(bc, axes) = axes
 
-
-
-Fields.space(bc::Base.Broadcast.Broadcasted{<:AbstractFieldStyle}) = axes(bc)
-
 function Base.similar(
     bc::Base.Broadcast.Broadcasted{<:AbstractFieldStyle},
     ::Type{Eltype},
@@ -88,10 +84,6 @@ function Base.copyto!(
     copyto!(field_values(dest), todata(bc))
     return dest
 end
-
-# Define the axes field to be the space of the return field
-# for checking Base.Broadcast.Broadcasted axes shapes
-Base.axes(field::Field) = Fields.space(field)
 
 
 function Base.Broadcast.broadcast_shape(

--- a/src/Fields/broadcast.jl
+++ b/src/Fields/broadcast.jl
@@ -64,13 +64,21 @@ function todata(bc::Base.Broadcast.Broadcasted{FieldStyle{DS}}) where {DS}
     Base.Broadcast.Broadcasted{DS}(bc.f, map(todata, bc.args))
 end
 
-Fields.space(bc::Base.Broadcast.Broadcasted{<:AbstractFieldStyle}) = axes(bc)[1]
+# same logic as Base.Broadcasted (which only defines it for Tuples)
+Base.axes(bc::Base.Broadcast.Broadcasted{<:AbstractFieldStyle}) =
+    _axes(bc, bc.axes)
+_axes(bc, ::Nothing) = Base.Broadcast.combine_axes(bc.args...)
+_axes(bc, axes) = axes
+
+
+
+Fields.space(bc::Base.Broadcast.Broadcasted{<:AbstractFieldStyle}) = axes(bc)
 
 function Base.similar(
     bc::Base.Broadcast.Broadcasted{<:AbstractFieldStyle},
     ::Type{Eltype},
 ) where {Eltype}
-    return Field(similar(todata(bc), Eltype), Fields.space(bc))
+    return Field(similar(todata(bc), Eltype), axes(bc))
 end
 
 function Base.copyto!(
@@ -81,14 +89,28 @@ function Base.copyto!(
     return dest
 end
 
-# Define the axes field to be a 1-tuple containing the space of the return field
+# Define the axes field to be the space of the return field
 # for checking Base.Broadcast.Broadcasted axes shapes
-Base.axes(field::Field) = (Fields.space(field),)
+Base.axes(field::Field) = Fields.space(field)
+
+
+function Base.Broadcast.broadcast_shape(
+    space1::AbstractSpace,
+    space2::AbstractSpace,
+)
+    if space1 !== space2
+        error("Mismatched spaces\n$space1\n$space2")
+    end
+    return space1
+end
+Base.Broadcast.broadcast_shape(space::AbstractSpace, ::Tuple{}) = space
+Base.Broadcast.broadcast_shape(::Tuple{}, space::AbstractSpace) = space
+
 
 # Overload broadcast axes shape checking for more useful error message for Field Spaces
 function Base.Broadcast.check_broadcast_shape(
-    (space1,)::Tuple{AbstractSpace},
-    (space2,)::Tuple{AbstractSpace},
+    space1::AbstractSpace,
+    space2::AbstractSpace,
 )
     if space1 !== space2
         error("Mismatched spaces\n$space1\n$space2")
@@ -96,13 +118,10 @@ function Base.Broadcast.check_broadcast_shape(
     return nothing
 end
 
-function Base.Broadcast.check_broadcast_shape(::Tuple{AbstractSpace}, ::Tuple{})
+function Base.Broadcast.check_broadcast_shape(::AbstractSpace, ::Tuple{})
     return nothing
 end
 
-function Base.Broadcast.check_broadcast_shape(
-    ::Tuple{AbstractSpace},
-    ax2::Tuple,
-)
+function Base.Broadcast.check_broadcast_shape(::AbstractSpace, ax2::Tuple)
     error("$ax2 is not a AbstractSpace")
 end

--- a/src/Fields/mapreduce.jl
+++ b/src/Fields/mapreduce.jl
@@ -5,7 +5,7 @@ weighted_jacobian(space::Spaces.FaceFiniteDifferenceSpace) = space.Δh_c2c
 weighted_jacobian(space::Spaces.CenterFiniteDifferenceSpace) = space.Δh_f2f
 weighted_jacobian(space::Spaces.SpectralElementSpace2D) =
     space.local_geometry.WJ
-weighted_jacobian(field) = weighted_jacobian(space(field))
+weighted_jacobian(field) = weighted_jacobian(axes(field))
 
 
 # sum will give the integral over the field

--- a/src/Operators/finitedifference.jl
+++ b/src/Operators/finitedifference.jl
@@ -232,7 +232,7 @@ return_space(::InterpolateC2F, space::Spaces.CenterFiniteDifferenceSpace) =
 stencil_interior_width(::InterpolateC2F) = ((-1, 0),)
 
 function stencil_interior(::InterpolateC2F, loc, idx, arg)
-    space = Fields.space(arg)
+    space = axes(arg)
     #RecursiveApply.rdiv(((getidx(arg, loc, idx) ⊠ space.Δh_f2f[idx]) ⊞ (getidx(arg, loc, idx - 1) ⊠ space.Δh_f2f[idx-1])), 2 ⊠ space.Δh_c2c[idx])
     RecursiveApply.rdiv(getidx(arg, loc, idx) ⊞ getidx(arg, loc, idx - 1), 2)
 end
@@ -243,14 +243,14 @@ function stencil_left_boundary(::InterpolateC2F, bc::SetValue, loc, idx, arg)
     bc.val
 end
 function stencil_right_boundary(::InterpolateC2F, bc::SetValue, loc, idx, arg)
-    space = Fields.space(arg)
+    space = axes(arg)
     @assert idx == length(space.Δh_c2c)
     bc.val
 end
 
 boundary_width(op::InterpolateC2F, ::SetGradient) = 1
 function stencil_left_boundary(::InterpolateC2F, bc::SetGradient, loc, idx, arg)
-    space = Fields.space(arg)
+    space = axes(arg)
     @assert idx == 1
     # Δh_c2c[1] is f1 to c1 distance
     getidx(arg, loc, idx) ⊟ (space.Δh_c2c[idx] ⊠ bc.val)
@@ -262,14 +262,14 @@ function stencil_right_boundary(
     idx,
     arg,
 )
-    space = Fields.space(arg)
+    space = axes(arg)
     @assert idx == length(space.Δh_c2c) # n+1
     getidx(arg, loc, idx - 1) ⊞ (space.Δh_c2c[idx] ⊠ bc.val)
 end
 
 boundary_width(op::InterpolateC2F, ::Extrapolate) = 1
 function stencil_left_boundary(::InterpolateC2F, bc::Extrapolate, loc, idx, arg)
-    space = Fields.space(arg)
+    space = axes(arg)
     @assert idx == 1
     # Δh_c2c[1] is f1 to c1 distance
     getidx(arg, loc, idx)
@@ -281,7 +281,7 @@ function stencil_right_boundary(
     idx,
     arg,
 )
-    space = Fields.space(arg)
+    space = axes(arg)
     @assert idx == length(space.Δh_c2c) # n+1
     getidx(arg, loc, idx - 1)
 end
@@ -380,7 +380,7 @@ return_space(::GradientF2C, space::Spaces.FaceFiniteDifferenceSpace) =
 stencil_interior_width(::GradientF2C) = ((0, 1),)
 
 function stencil_interior(::GradientF2C, loc, idx, arg)
-    space = Fields.space(arg)
+    space = axes(arg)
     RecursiveApply.rdiv(
         (getidx(arg, loc, idx + 1) ⊟ getidx(arg, loc, idx)),
         space.Δh_f2f[idx],
@@ -389,13 +389,13 @@ end
 
 boundary_width(op::GradientF2C, ::SetValue) = 1
 function stencil_left_boundary(::GradientF2C, bc::SetValue, loc, idx, arg)
-    space = Fields.space(arg)
+    space = axes(arg)
     @assert idx == 1
     RecursiveApply.rdiv((getidx(arg, loc, idx + 1) ⊟ bc.val), space.Δh_f2f[idx])
 end
 
 function stencil_right_boundary(::GradientF2C, bc::SetValue, loc, idx, arg)
-    space = Fields.space(arg)
+    space = axes(arg)
     # Δh_f2f = [f[2] - f[1], f[3] - f[2], ..., f[n] - f[n-1], f[n+1] - f[n]]
     @assert idx == length(space.Δh_f2f) # n
     RecursiveApply.rdiv((bc.val ⊟ getidx(arg, loc, idx)), space.Δh_f2f[idx])
@@ -404,12 +404,12 @@ end
 
 boundary_width(op::GradientF2C, ::Extrapolate) = 1
 function stencil_left_boundary(op::GradientF2C, ::Extrapolate, loc, idx, arg)
-    space = Fields.space(arg)
+    space = axes(arg)
     @assert idx == 1
     stencil_interior(op, loc, idx + 1, arg)
 end
 function stencil_right_boundary(op::GradientF2C, ::Extrapolate, loc, idx, arg)
-    space = Fields.space(arg)
+    space = axes(arg)
     # Δh_f2f = [f[2] - f[1], f[3] - f[2], ..., f[n] - f[n-1], f[n+1] - f[n]]
     @assert idx == length(space.Δh_f2f) # n
     stencil_interior(op, loc, idx - 1, arg)
@@ -435,7 +435,7 @@ return_space(::GradientC2F, space::Spaces.CenterFiniteDifferenceSpace) =
 stencil_interior_width(::GradientC2F) = ((-1, 0),)
 
 function stencil_interior(::GradientC2F, loc, idx, arg)
-    space = Fields.space(arg)
+    space = axes(arg)
     RecursiveApply.rdiv(
         (getidx(arg, loc, idx) ⊟ getidx(arg, loc, idx - 1)),
         space.Δh_c2c[idx],
@@ -446,14 +446,14 @@ boundary_width(op::GradientC2F, ::SetValue) = 1
 boundary_width(op::GradientC2F, ::SetGradient) = 1
 
 function stencil_left_boundary(::GradientC2F, bc::SetValue, loc, idx, arg)
-    space = Fields.space(arg)
+    space = axes(arg)
     @assert idx == 1
     # Δh_c2c[1] is f1 to c1 distance
     RecursiveApply.rdiv((getidx(arg, loc, idx) ⊟ bc.val), space.Δh_c2c[idx])
 end
 
 function stencil_right_boundary(::GradientC2F, bc::SetValue, loc, idx, arg)
-    space = Fields.space(arg)
+    space = axes(arg)
     # Δh_c2c = [c[1] - f[1], c[2] - c[1], ..., c[n] - c[n-1], f[n+1] - c[n]]
     @assert idx == length(space.Δh_c2c) # n+1
     # Δh_c2c[end] is c[n] to f[n+1] distance
@@ -468,7 +468,7 @@ function stencil_left_boundary(::GradientC2F, bc::SetGradient, loc, idx, arg)
 end
 
 function stencil_right_boundary(::GradientC2F, bc::SetGradient, loc, idx, arg)
-    space = Fields.space(arg)
+    space = axes(arg)
     @assert idx == length(space.Δh_c2c)  # n+1
     # imposed flux boundary condition at right most face
     bc.val
@@ -531,7 +531,7 @@ function right_boundary_window_width(
             (a, w) ->
                 right_boundary_window_width(a, loc) +
                 w[2] +
-                stagger_correct(Fields.space(bc), Fields.space(a)),
+                stagger_correct(axes(bc), axes(a)),
             args,
             stencil_interior_width(op),
         ),
@@ -591,7 +591,7 @@ function getidx(
     idx,
 )
     op = bc.f
-    n = length(Fields.space(bc))
+    n = length(axes(bc))
     if idx > (n - right_boundary_width(bc, loc))
         stencil_right_boundary(op, get_boundary(op, loc), loc, idx, bc.args...)
     else
@@ -636,8 +636,8 @@ function Base.Broadcast.broadcasted(
     op::FiniteDifferenceOperator,
     args...,
 )
-    axes = return_space(op, map(Fields.space, args)...)
-    Base.Broadcast.Broadcasted{StencilStyle}(op, args, axes)
+    ax = return_space(op, map(axes, args)...)
+    Base.Broadcast.Broadcasted{StencilStyle}(op, args, ax)
 end
 
 Base.Broadcast.instantiate(bc::Base.Broadcast.Broadcasted{StencilStyle}) = bc
@@ -645,13 +645,11 @@ Base.Broadcast._broadcast_getindex_eltype(
     bc::Base.Broadcast.Broadcasted{StencilStyle},
 ) = eltype(bc)
 
-Fields.space(bc::Base.Broadcast.Broadcasted{StencilStyle}) = axes(bc)
-
 function Base.similar(
     bc::Base.Broadcast.Broadcasted{S},
     ::Type{Eltype},
 ) where {Eltype, S <: AbstractStencilStyle}
-    sp = Fields.space(bc)
+    sp = axes(bc)
     return Field(similar(Spaces.coordinates(sp), Eltype), sp)
 end
 
@@ -664,12 +662,11 @@ function Base.copyto!(
     return field_out
 end
 
-Spaces.interior_indices(field::Field) = Spaces.real_indices(Fields.space(field))
+Spaces.interior_indices(field::Field) = Spaces.real_indices(axes(field))
 
 Spaces.interior_indices(
     field::Base.Broadcast.Broadcasted{FS},
-) where {FS <: Fields.AbstractFieldStyle} =
-    Spaces.real_indices(Fields.space(field))
+) where {FS <: Fields.AbstractFieldStyle} = Spaces.real_indices(axes(field))
 
 function Spaces.interior_indices(bc::Base.Broadcast.Broadcasted{StencilStyle})
     width_op = stencil_interior_width(bc.f)   # tuple of 2-tuples
@@ -681,7 +678,7 @@ function Spaces.interior_indices(bc::Base.Broadcast.Broadcasted{StencilStyle})
 end
 
 function apply_stencil!(data_out, bc)
-    space = Fields.space(bc)
+    space = axes(bc)
     n = length(space)
     lb = LeftBoundaryWindow{Spaces.left_boundary_name(space)}()
     rb = RightBoundaryWindow{Spaces.right_boundary_name(space)}()

--- a/src/Operators/finitedifference.jl
+++ b/src/Operators/finitedifference.jl
@@ -636,7 +636,7 @@ function Base.Broadcast.broadcasted(
     op::FiniteDifferenceOperator,
     args...,
 )
-    axes = (return_space(op, map(Fields.space, args)...),)
+    axes = return_space(op, map(Fields.space, args)...)
     Base.Broadcast.Broadcasted{StencilStyle}(op, args, axes)
 end
 
@@ -645,7 +645,7 @@ Base.Broadcast._broadcast_getindex_eltype(
     bc::Base.Broadcast.Broadcasted{StencilStyle},
 ) = eltype(bc)
 
-Fields.space(bc::Base.Broadcast.Broadcasted{StencilStyle}) = axes(bc)[1]
+Fields.space(bc::Base.Broadcast.Broadcasted{StencilStyle}) = axes(bc)
 
 function Base.similar(
     bc::Base.Broadcast.Broadcasted{S},

--- a/src/Operators/numericalflux.jl
+++ b/src/Operators/numericalflux.jl
@@ -23,7 +23,7 @@ See also:
 - [`RusanovNumericalFlux`](@ref)
 """
 function add_numerical_flux_internal!(fn, dydt, args...)
-    space = Fields.space(dydt)
+    space = axes(dydt)
     Nq = Spaces.Quadratures.degrees_of_freedom(space.quadrature_style)
     topology = space.topology
 
@@ -99,7 +99,7 @@ end
 
 
 function add_numerical_flux_boundary!(fn, dydt, args...)
-    space = Fields.space(dydt)
+    space = axes(dydt)
     Nq = Spaces.Quadratures.degrees_of_freedom(space.quadrature_style)
     topology = space.topology
 

--- a/src/Operators/spectralelement.jl
+++ b/src/Operators/spectralelement.jl
@@ -307,29 +307,29 @@ end
 
 
 function slab_gradient!(∇field::Field, field::Field)
-    @assert Fields.space(∇field) === Fields.space(field)
+    @assert axes(∇field) === axes(field)
     Operators.slab_gradient!(
         Fields.field_values(∇field),
         Fields.field_values(field),
-        Fields.space(field),
+        axes(field),
     )
     return ∇field
 end
 function slab_divergence!(divflux::Field, flux::Field)
-    @assert Fields.space(divflux) === Fields.space(flux)
+    @assert axes(divflux) === axes(flux)
     Operators.slab_divergence!(
         Fields.field_values(divflux),
         Fields.field_values(flux),
-        Fields.space(flux),
+        axes(flux),
     )
     return divflux
 end
 function slab_weak_divergence!(divflux::Field, flux::Field)
-    @assert Fields.space(divflux) === Fields.space(flux)
+    @assert axes(divflux) === axes(flux)
     Operators.slab_weak_divergence!(
         Fields.field_values(divflux),
         Fields.field_values(flux),
-        Fields.space(flux),
+        axes(flux),
     )
     return divflux
 end
@@ -358,8 +358,8 @@ function interpolate(space_to::AbstractSpace, field_from::Field)
     interpolate!(field_to, field_from)
 end
 function interpolate!(field_to::Field, field_from::Field)
-    space_to = Fields.space(field_to)
-    space_from = Fields.space(field_from)
+    space_to = axes(field_to)
+    space_from = axes(field_from)
     # @assert space_from.topology == space_to.topology
 
     M = Quadratures.interpolation_matrix(
@@ -376,8 +376,8 @@ function interpolate!(field_to::Field, field_from::Field)
 end
 
 function restrict!(field_to::Field, field_from::Field)
-    space_to = Fields.space(field_to)
-    space_from = Fields.space(field_from)
+    space_to = axes(field_to)
+    space_from = axes(field_from)
     # @assert space_from.topology == space_to.topology
 
     M = Quadratures.interpolation_matrix(
@@ -398,7 +398,7 @@ function matrix_interpolate(
     Q_interp::Quadratures.Uniform{Nu},
 ) where {Nu}
     S = eltype(field)
-    space = Fields.space(field)
+    space = axes(field)
     mesh = space.topology.mesh
     n1 = mesh.n1
     n2 = mesh.n2

--- a/src/Plots/plots.jl
+++ b/src/Plots/plots.jl
@@ -11,7 +11,7 @@ function UnicodePlots.heatmap(
         error("Can only plot heatmaps of scalar fields")
     end
 
-    space = Fields.space(field)
+    space = axes(field)
     mesh = space.topology.mesh
     n1 = mesh.n1
     n2 = mesh.n2
@@ -47,7 +47,7 @@ function UnicodePlots.lineplot(
     else
         name = :x
     end
-    space = Fields.space(field)
+    space = axes(field)
 
     xlabel = repr(name) * " value"
     xdata = Array(parent(field))[:, 1]
@@ -75,7 +75,7 @@ end
 
 RecipesBase.@recipe function f(field::Fields.FiniteDifferenceField)
     # unwrap the data to plot
-    space = Fields.space(field)
+    space = axes(field)
     xdata = parent(field)[:, 1]
     ydata = parent(Spaces.coordinates(space))[:, 1]
 
@@ -99,8 +99,8 @@ RecipesBase.@recipe function f(field::Fields.FiniteDifferenceField)
 end
 
 RecipesBase.@recipe function f(field::Fields.SpectralElementField2D)
-    # compute the interpolated data to plot 
-    space = Fields.space(field)
+    # compute the interpolated data to plot
+    space = axes(field)
     mesh = space.topology.mesh
     n1 = mesh.n1
     n2 = mesh.n2

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -23,7 +23,7 @@ using LinearAlgebra, IntervalSets
     ∇data = Operators.slab_gradient!(
         similar(data, NTuple{2, Geometry.Cartesian12Vector{Float64}}),
         data,
-        Fields.space(field),
+        axes(field),
     )
     @test parent(∇data) ≈
           Float64[f == 1 || f == 4 for i in 1:Nq, j in 1:Nq, f in 1:4, h in 1:1]
@@ -45,7 +45,7 @@ end
     ∇data = Operators.slab_gradient!(
         similar(data, Geometry.Cartesian12Vector{Float64}),
         data,
-        Fields.space(field),
+        axes(field),
     )
     @test parent(∇data.u1) ≈
           parent(Fields.field_values(cos.(Fields.coordinate_field(space).x1))) rtol =
@@ -87,11 +87,8 @@ end
     field = f.(Fields.coordinate_field(space))
 
     data = Fields.field_values(field)
-    div_data = Operators.slab_divergence!(
-        similar(data, Float64),
-        data,
-        Fields.space(field),
-    )
+    div_data =
+        Operators.slab_divergence!(similar(data, Float64), data, axes(field))
     divf(x) = sin(x.x1 + x.x2)
     @test parent(div_data) ≈
           parent(Fields.field_values(divf.(Fields.coordinate_field(space)))) rtol =


### PR DESCRIPTION
This turns out to be easier than I originally thought. It also means we can remove `Fields.space`, as it is no longer needed.